### PR TITLE
do not generate unique id on background job submission

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,8 +283,7 @@ func (client *Client) writeJob(job *Job) {
 
 // Internal do
 func (client *Client) do(funcname string, data []byte,
-flag uint32) (id string, handle string) {
-    id = strconv.Itoa(int(ai.Id()))
+flag uint32, id string) (handle string) {
     l := len(funcname) + len(id) + len(data) + 2
     rel := make([]byte, 0, l)
     rel = append(rel, []byte(funcname)...)          // len(funcname)
@@ -317,8 +316,8 @@ flag byte, jobhandler JobHandler) (handle string) {
     default:
         datatype = common.SUBMIT_JOB
     }
-    var id string
-    id, handle = client.do(funcname, data, datatype)
+    id := strconv.Itoa(int(ai.Id()))
+    handle = client.do(funcname, data, datatype, id)
     if jobhandler != nil {
         client.jobhandlers[id] = jobhandler
     }
@@ -336,7 +335,7 @@ flag byte) (handle string) {
     default:
         datatype = common.SUBMIT_JOB_BG
     }
-    _, handle = client.do(funcname, data, datatype)
+    handle = client.do(funcname, data, datatype, "")
     return
 }
 


### PR DESCRIPTION
Hi Xing Xing,

the gearman protocol doesn't require unique ids and the client library doesn't use them.
The implemenation using an autoincrement is also problematic with submitting background jobs in chunks with multiple invocations of a job submission binary.

I went the easiest way of just removing the unique id for background job submission. This is actually fine according to http://gearman.org/protocol (in the example protocol session)

The problem with uniqe ids and background jobs looks like this:
- I have a submission binary submitting fully verified jobs to gearman, but not waiting for the result.
- Another worker binary is listening for these jobs

When I call the submission binary in a loop, I get duplicate gearman job ids and only the first job is processed by the worker. 

The submitter can not detect this failed submission, so avoiding it seems sane.

Another possible fix is to use uuids instead of autoinc, but I guess you used autoinc for good reasons :-)

Please merge.

Cheers
          Ingo
