### PR TITLE
Remove depenance on external libs for unique id

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-    IdGen = NewObjectId()
+	IdGen = NewAutoIncId()
 }
 
 // Status handler

--- a/client/id_test.go
+++ b/client/id_test.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestAutoInc(t *testing.T) {
+	ai := NewAutoIncId()
+
+	previous := ai.Id()
+	for i := 0; i < 10; i++ {
+		id := ai.Id()
+		if id == previous {
+			t.Errorf("Id not unique, previous and current %s", id)
+		}
+		previous = id
+	}
+}


### PR DESCRIPTION
I didn't want to have to include "labix.org/v2/mgo/bson" and "github.com/mikespook/golib" in my project just for this little function, so I added a simple auto increment id generator. The code using the IdGenerator interface made it easy.

Note: the id needs to unique across currently running jobs, so I feel the method used below is adequate. 
