### PR TITLE
Remove handle only when the job is done

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -213,9 +213,10 @@ func (client *Client) inLoop() {
         case common.ERROR:
             _, err := common.GetError(job.Data)
             client.err(err)
-        case common.WORK_DATA, common.WORK_WARNING, common.WORK_STATUS,
-            common.WORK_COMPLETE, common.WORK_FAIL, common.WORK_EXCEPTION:
-            client.handleJob(job)
+        case common.WORK_DATA, common.WORK_WARNING, common.WORK_STATUS:
+            client.handleJob(job, false)
+        case common.WORK_COMPLETE, common.WORK_FAIL, common.WORK_EXCEPTION:
+            client.handleJob(job, true)
         case common.ECHO_RES:
             client.handleEcho(job)
         case common.JOB_CREATED:
@@ -236,12 +237,14 @@ func (client *Client) err (e error) {
 }
 
 // job handler
-func (client *Client) handleJob(job *Job) {
+func (client *Client) handleJob(job *Job, terminate bool) {
     client.mutex.RLock()
     defer client.mutex.RUnlock()
     if h, ok := client.jobhandlers[job.Handle]; ok {
         h(job)
-        delete(client.jobhandlers, job.Handle)
+        if terminate {
+            delete(client.jobhandlers, job.Handle)
+        }
     }
 }
 


### PR DESCRIPTION
This commit stops the client from removing the job handle from
client.jobhandlers when the worker has sent an update (e.g. WORK_STATUS)
without terminating its life.

Notification:

WORK_DATA
WORK_WARNING
WORK_STATUS

Notification + end of life:

WORK_COMPLETE
WORK_FAIL
WORK_EXCEPTION
