### PR TITLE
expose job handle/uniqueId

### DIFF
--- a/worker/inpack.go
+++ b/worker/inpack.go
@@ -24,6 +24,14 @@ func (inpack *inPack) Data() []byte {
 	return inpack.data
 }
 
+func (inpack *inPack) Handle() string {
+	return inpack.handle
+}
+
+func (inpack *inPack) UniqueId() string {
+	return inpack.uniqueId
+}
+
 func (inpack *inPack) Err() error {
 	if inpack.dataType == dtError {
 		return getError(inpack.data)

--- a/worker/job.go
+++ b/worker/job.go
@@ -6,4 +6,6 @@ type Job interface {
 	SendWarning(data []byte)
 	SendData(data []byte)
 	UpdateStatus(numerator, denominator int)
+	Handle() string
+	UniqueId() string
 }


### PR DESCRIPTION
In some of your recent refactoring, you made these fields private, causing our builds to start failing. Our worker functions need access to them because we do things like create job-specific temp directories using the job handle.
