### PR TITLE
Bring back ability to get function name

### DIFF
--- a/worker/inpack.go
+++ b/worker/inpack.go
@@ -24,6 +24,10 @@ func (inpack *inPack) Data() []byte {
 	return inpack.data
 }
 
+func (inpack *inPack) Fn() string {
+	return inpack.fn
+}
+
 func (inpack *inPack) Handle() string {
 	return inpack.handle
 }

--- a/worker/job.go
+++ b/worker/job.go
@@ -3,6 +3,7 @@ package worker
 type Job interface {
 	Err() error
 	Data() []byte
+	Fn() string
 	SendWarning(data []byte)
 	SendData(data []byte)
 	UpdateStatus(numerator, denominator int)


### PR DESCRIPTION
Current library at http://github.com/300brand/disgo depends on job's function name
