### PR TITLE
Clarify timeout option in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Usage
         log.Println(e)
     }
     w.AddServer("127.0.0.1:4730")
+    // this will give a timeout of 2 seconds. Use worker.Unlimited (0) if you want no timeout
     w.AddFunc("ToUpper", ToUpper, worker.Immediately)
     w.AddFunc("ToUpperTimeOut5", ToUpper, 5)
 	if err := w.Ready(); err != nil {


### PR DESCRIPTION
worker.Immediately has value 2 which means the job will timeout after 2 seconds (maybe not very intuitive?). To have no timeout one has to pass the value 0 which is also constant worker.Unlimited (more intuitive)
