### PR TITLE
Printf fixes

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -19,7 +19,7 @@ var (
 func getError(data []byte) (err error) {
 	rel := bytes.SplitN(data, []byte{'\x00'}, 2)
 	if len(rel) != 2 {
-		err = fmt.Errorf("Not a error data: %V", data)
+		err = fmt.Errorf("Not a error data: %v", data)
 		return
 	}
 	err = fmt.Errorf("%s: %s", rel[0], rel[1])

--- a/client/response.go
+++ b/client/response.go
@@ -57,17 +57,17 @@ func (resp *Response) Update() (data []byte, err error) {
 func decodeResponse(data []byte) (resp *Response, l int, err error) {
 	a := len(data)
 	if a < minPacketLength { // valid package should not less 12 bytes
-		err = fmt.Errorf("Invalid data: %V", data)
+		err = fmt.Errorf("Invalid data: %v", data)
 		return
 	}
 	dl := int(binary.BigEndian.Uint32(data[8:12]))
 	if a < minPacketLength+dl {
-		err = fmt.Errorf("Invalid data: %V", data)
+		err = fmt.Errorf("Invalid data: %v", data)
 		return
 	}
 	dt := data[minPacketLength : dl+minPacketLength]
 	if len(dt) != int(dl) { // length not equal
-		err = fmt.Errorf("Invalid data: %V", data)
+		err = fmt.Errorf("Invalid data: %v", data)
 		return
 	}
 	resp = getResponse()
@@ -82,7 +82,7 @@ func decodeResponse(data []byte) (resp *Response, l int, err error) {
 			resp.Handle = string(s[0])
 			resp.Data = s[1]
 		} else {
-			err = fmt.Errorf("Invalid data: %V", data)
+			err = fmt.Errorf("Invalid data: %v", data)
 			return
 		}
 	case dtEchoRes:
@@ -97,7 +97,7 @@ func decodeResponse(data []byte) (resp *Response, l int, err error) {
 func (resp *Response) Status() (status *Status, err error) {
 	data := bytes.SplitN(resp.Data, []byte{'\x00'}, 2)
 	if len(data) != 2 {
-		err = fmt.Errorf("Invalid data: %V", resp.Data)
+		err = fmt.Errorf("Invalid data: %v", resp.Data)
 		return
 	}
 	status = &Status{}
@@ -121,7 +121,7 @@ func (resp *Response) Status() (status *Status, err error) {
 func (resp *Response) _status() (status *Status, err error) {
 	data := bytes.SplitN(resp.Data, []byte{'\x00'}, 4)
 	if len(data) != 4 {
-		err = fmt.Errorf("Invalid data: %V", resp.Data)
+		err = fmt.Errorf("Invalid data: %v", resp.Data)
 		return
 	}
 	status = &Status{}

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -34,7 +34,7 @@ func main() {
 			fallthrough
 		case client.WorkComplate:
 			if data, err := resp.Result(); err == nil {
-				log.Printf("RESULT: %V\n", data)
+				log.Printf("RESULT: %v\n", data)
 			} else {
 				log.Printf("RESULT: %s\n", err)
 			}
@@ -42,18 +42,18 @@ func main() {
 			fallthrough
 		case client.WorkData:
 			if data, err := resp.Update(); err == nil {
-				log.Printf("UPDATE: %V\n", data)
+				log.Printf("UPDATE: %v\n", data)
 			} else {
-				log.Printf("UPDATE: %V, %s\n", data, err)
+				log.Printf("UPDATE: %v, %s\n", data, err)
 			}
 		case client.WorkStatus:
 			if data, err := resp.Status(); err == nil {
-				log.Printf("STATUS: %V\n", data)
+				log.Printf("STATUS: %v\n", data)
 			} else {
 				log.Printf("STATUS: %s\n", err)
 			}
 		default:
-			log.Printf("UNKNOWN: %V", resp.Data)
+			log.Printf("UNKNOWN: %v", resp.Data)
 		}
 	}
 	handle, err := c.Do("ToUpper", echo, client.JobNormal, jobHandler)
@@ -64,7 +64,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Printf("%t", status)
+	log.Printf("%v", *status)
 
 	_, err = c.Do("Foobar", echo, client.JobNormal, jobHandler)
 	if err != nil {

--- a/worker/error.go
+++ b/worker/error.go
@@ -18,7 +18,7 @@ var (
 func getError(data []byte) (err error) {
 	rel := bytes.SplitN(data, []byte{'\x00'}, 2)
 	if len(rel) != 2 {
-		err = fmt.Errorf("Not a error data: %V", data)
+		err = fmt.Errorf("Not a error data: %v", data)
 		return
 	}
 	err = fmt.Errorf("%s: %s", rel[0], rel[1])

--- a/worker/inpack.go
+++ b/worker/inpack.go
@@ -87,17 +87,17 @@ func (inpack *inPack) UpdateStatus(numerator, denominator int) {
 // Decode job from byte slice
 func decodeInPack(data []byte) (inpack *inPack, l int, err error) {
 	if len(data) < minPacketLength { // valid package should not less 12 bytes
-		err = fmt.Errorf("Invalid data: %V", data)
+		err = fmt.Errorf("Invalid data: %v", data)
 		return
 	}
 	dl := int(binary.BigEndian.Uint32(data[8:12]))
 	if len(data) < (dl + minPacketLength) {
-		err = fmt.Errorf("Not enough data: %V", data)
+		err = fmt.Errorf("Not enough data: %v", data)
 		return
 	}
 	dt := data[minPacketLength : dl+minPacketLength]
 	if len(dt) != int(dl) { // length not equal
-		err = fmt.Errorf("Invalid data: %V", data)
+		err = fmt.Errorf("Invalid data: %v", data)
 		return
 	}
 	inpack = getInPack()


### PR DESCRIPTION
This fixes some printf-related issues.

   1) using %V instead of %v .  (Uppercase V is not a valid printf verb)
   2) fmt.Errorf() instead of errors.New(fmt.Sprintf())
