### PR TITLE
Allow ID generator to hash the payload

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -192,7 +192,7 @@ func (client *Client) do(funcname string, data []byte,
 		handle = resp.Handle
 		mutex.Unlock()
 	}
-	id := IdGen.Id()
+	id := IdGen.Id(funcname, string(data))
 	req := getJob(id, []byte(funcname), data)
 	req.DataType = flag
 	client.write(req)

--- a/client/id.go
+++ b/client/id.go
@@ -16,10 +16,10 @@ func init() {
 	IdGen = NewAutoIncId()
 }
 
-// ID generator interface. Users can implament this for
+// ID generator interface. Users can implement this for
 // their own generator.
 type IdGenerator interface {
-	Id() string
+	Id(funcname, payload string) string
 }
 
 // AutoIncId
@@ -27,7 +27,7 @@ type autoincId struct {
 	value int64
 }
 
-func (ai *autoincId) Id() string {
+func (ai *autoincId) Id(funcname, payload string) string {
 	next := atomic.AddInt64(&ai.value, 1)
 	return strconv.FormatInt(next, 10)
 }

--- a/client/id_test.go
+++ b/client/id_test.go
@@ -7,9 +7,9 @@ import (
 func TestAutoInc(t *testing.T) {
 	ai := NewAutoIncId()
 
-	previous := ai.Id()
+	previous := ai.Id("testfuncname", "fakepayload")
 	for i := 0; i < 10; i++ {
-		id := ai.Id()
+		id := ai.Id("testfuncname", "fakepayload2")
 		if id == previous {
 			t.Errorf("Id not unique, previous and current %s", id)
 		}


### PR DESCRIPTION
The unique ID passed to gearman is used to avoid duplicate work.  I want to make use of that feature, so I need the unique ID to be a hash of funcname+payload.

I went ahead and implemented an IdGenerator type in my own project to do this, but I need the interface to support sending the funcname and payload as parameters, so I changed your code as well.  It should be harmless to include in your project and may help others, hence this pull request.

For reference, my IdGenerator implementation looks like this (has not been tested and I'm very new to Go):

``` go
type gearmanIdGen gearmanclient.IdGenerator
func (ci *gearmanIdGen) Id(funcname, payload string) string {
    return hex.encodeToString(sha1.Sum(funcname+payload))
}
```

You may want to consider this behavior as the default behavior, assuming I'm correct that gearman uses the unique id for this purpose.
