### PR TITLE
More helpful panic if you call Work() before you call Ready()

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -22,6 +22,7 @@ type Worker struct {
 	funcs   jobFuncs
 	in      chan *inPack
 	running bool
+	ready bool
 
 	Id           string
 	ErrorHandler ErrorHandler
@@ -174,12 +175,17 @@ func (worker *Worker) Ready() (err error) {
 	for funcname, f := range worker.funcs {
 		worker.addFunc(funcname, f.timeout)
 	}
+	worker.ready = true
 	return
 }
 
 // Main loop, block here
 // Most of time, this should be evaluated in goroutine.
 func (worker *Worker) Work() {
+	if ! worker.ready {
+		panic( "worker: Work() called before Ready()")
+	}
+
 	defer func() {
 		for _, a := range worker.agents {
 			a.Close()


### PR DESCRIPTION
If you set up a worker, but don't call Ready() (which is obviously wrong I'll admit), you get a complex and unhelpful panic because the worker is not in a good state. All this adds is a check that Ready has been called on the worker, if not the code will still panic but with a more helpful message.

I am not sure that a panic is the 100% best solution, but since that is what happens in this situation I thought I'd try and save the next person who hits this issue a safety net.
