### PR TITLE
When a job completes, remove its handler

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -145,10 +145,8 @@ func (client *Client) processLoop() {
 		case dtWorkData, dtWorkWarning, dtWorkStatus:
 			resp = client.handleResponse(resp.Handle, resp)
 		case dtWorkComplete, dtWorkFail, dtWorkException:
-			resp = client.handleResponse(resp.Handle, resp)
-			if resp != nil {
-				delete(client.respHandler, resp.Handle)
-			}
+			client.handleResponse(resp.Handle, resp)
+			delete(client.respHandler, resp.Handle)
 		}
 	}
 }


### PR DESCRIPTION
When gearman sends dtWorkComplete, dtWorkFail or dtWorkException to a client
that is the last packet it will send for that job. So we need to always remove
the handler or we continuously consume memory
