### PR TITLE
Allow custom Pool without constructor

### DIFF
--- a/client/pool.go
+++ b/client/pool.go
@@ -52,9 +52,9 @@ func selectRandom(pool map[string]*PoolClient,
 type Pool struct {
 	SelectionHandler SelectionHandler
 	ErrorHandler     ErrorHandler
+	Clients          map[string]*PoolClient
 
-	clients map[string]*PoolClient
-	last    string
+	last string
 
 	mutex sync.Mutex
 }
@@ -62,7 +62,7 @@ type Pool struct {
 // Return a new pool.
 func NewPool() (pool *Pool) {
 	return &Pool{
-		clients:          make(map[string]*PoolClient, poolSize),
+		Clients:          make(map[string]*PoolClient, poolSize),
 		SelectionHandler: SelectWithRate,
 	}
 }
@@ -73,14 +73,14 @@ func (pool *Pool) Add(net, addr string, rate int) (err error) {
 	defer pool.mutex.Unlock()
 	var item *PoolClient
 	var ok bool
-	if item, ok = pool.clients[addr]; ok {
+	if item, ok = pool.Clients[addr]; ok {
 		item.Rate = rate
 	} else {
 		var client *Client
 		client, err = New(net, addr)
 		if err == nil {
 			item = &PoolClient{Client: client, Rate: rate}
-			pool.clients[addr] = item
+			pool.Clients[addr] = item
 		}
 	}
 	return
@@ -90,7 +90,7 @@ func (pool *Pool) Add(net, addr string, rate int) (err error) {
 func (pool *Pool) Remove(addr string) {
 	pool.mutex.Lock()
 	defer pool.mutex.Unlock()
-	delete(pool.clients, addr)
+	delete(pool.Clients, addr)
 }
 
 func (pool *Pool) Do(funcname string, data []byte,
@@ -116,7 +116,7 @@ func (pool *Pool) DoBg(funcname string, data []byte,
 // Get job status from job server.
 // !!!Not fully tested.!!!
 func (pool *Pool) Status(addr, handle string) (status *Status, err error) {
-	if client, ok := pool.clients[addr]; ok {
+	if client, ok := pool.Clients[addr]; ok {
 		client.Lock()
 		defer client.Unlock()
 		status, err = client.Status(handle)
@@ -133,7 +133,7 @@ func (pool *Pool) Echo(addr string, data []byte) (echo []byte, err error) {
 		client = pool.selectServer()
 	} else {
 		var ok bool
-		if client, ok = pool.clients[addr]; !ok {
+		if client, ok = pool.Clients[addr]; !ok {
 			err = ErrNotFound
 			return
 		}
@@ -147,7 +147,7 @@ func (pool *Pool) Echo(addr string, data []byte) (echo []byte, err error) {
 // Close
 func (pool *Pool) Close() (err map[string]error) {
 	err = make(map[string]error)
-	for _, c := range pool.clients {
+	for _, c := range pool.Clients {
 		err[c.addr] = c.Close()
 	}
 	return
@@ -156,9 +156,9 @@ func (pool *Pool) Close() (err map[string]error) {
 // selecting server
 func (pool *Pool) selectServer() (client *PoolClient) {
 	for client == nil {
-		addr := pool.SelectionHandler(pool.clients, pool.last)
+		addr := pool.SelectionHandler(pool.Clients, pool.last)
 		var ok bool
-		if client, ok = pool.clients[addr]; ok {
+		if client, ok = pool.Clients[addr]; ok {
 			pool.last = addr
 			break
 		}

--- a/client/pool_test.go
+++ b/client/pool_test.go
@@ -18,8 +18,8 @@ func TestPoolAdd(t *testing.T) {
 		t.Log(err)
 		c -= 1
 	}
-	if len(pool.clients) != c {
-		t.Errorf("%d servers expected, %d got.", c, len(pool.clients))
+	if len(pool.Clients) != c {
+		t.Errorf("%d servers expected, %d got.", c, len(pool.Clients))
 	}
 }
 


### PR DESCRIPTION
This will allow custom `selectionHandler` and `errorHandler` for the Pool.
Better solution than https://github.com/mikespook/gearman-go/pull/61