### PR TITLE
Add sync lock to create job functions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -221,6 +221,8 @@ func (client *Client) do(funcname string, data []byte,
 		return "", ErrLostConn
 	}
 	var result = make(chan handleOrError, 1)
+	client.Lock()
+	defer client.Unlock()
 	client.lastcall = "c"
 	client.innerHandler.put("c", func(resp *Response) {
 		if resp.DataType == dtError {


### PR DESCRIPTION
Add sync lock to make create job calls thread safe.