### PR TITLE
fixed typo on WorkComplete

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -51,6 +51,7 @@ const (
 	dtSubmitJobLowBg  = 34
 
 	WorkComplate  = dtWorkComplete
+	WorkComplete  = dtWorkComplete
 	WorkData      = dtWorkData
 	WorkStatus    = dtWorkStatus
 	WorkWarning   = dtWorkWarning


### PR DESCRIPTION
fixed typo on `WorkComplete` and keep `WorkComplate` stay for downward compatibility