### PR TITLE
Fix two race conditions in client.Do

### DIFF
--- a/example/pl/worker_multi.pl
+++ b/example/pl/worker_multi.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+# Runs 20 children that expose "PerlToUpper" before returning the result.
+
+use strict; use warnings;
+use constant CHILDREN => 20;
+use Time::HiRes qw(usleep);
+use Gearman::Worker;
+
+$|++;
+my @child_pids;
+for (1 .. CHILDREN) {
+  if (my $pid = fork) {
+    push @child_pids, $pid;
+    next;
+  }
+  eval {
+    my $w = Gearman::Worker->new(job_servers => '127.0.0.1:4730');
+    $w->register_function(PerlToUpper => sub { print "."; uc $_[0]->arg });
+    $w->work while 1;
+  };
+  warn $@ if $@;
+  exit 0;
+}
+
+$SIG{INT} = $SIG{HUP} = sub {
+  kill 9, @child_pids;
+  print "\nChildren shut down, gracefully exiting\n";
+  exit 0;
+};
+
+printf "Forked %d children, serving 'PerlToUpper' function to gearman\n", CHILDREN;
+sleep;


### PR DESCRIPTION
* Common race condition is fixed by identifying that Client.respHandler can be completely removed since all respHandler operations (get, put and invocation) can be moved into the Client.processLoop goroutine, meaning that zero locking is required. This race condition resulted in a deadlock that was resolved by the response timeout at the end of client.Do, returning ErrLostConn
* Rare race condition is fixed by changing responseHandlerMap.get to .getAndRemove. This race condition resulted in the innerHandler for a new dtJobCreated assigned in client.Do overriding a stale older dtJobCreated request, and the newer innerHandler being removed by an older dtJobCreated in client.processLoop > client.handleInner. When the newer dtJobCreated response was received, the handler for it had already been deleted. This was resolved by the response timeout at the end of client.Do, returning ErrLostConn

I have added `examples/pl/worker_multi.pl` to create a bunch of workers for a new integration test to ferret out these race conditions. In more depth:

First race condition occurs in this scenario:
1. Req A: client.Do called, execution pauses at end of client.Do waiting for dtJobCreated result
2. Req A: Server sends dtJobCreated, handle created
3. Req A: client.Do call completes. dtJobCompleted for Req A is yet to be sent
4. Req B: client.Do called, locks client.respHandler
5. Req A: Server sends dtWorkComplete for Req A. client.processLoop is unable to invoke the callback as respHandler is locked by another goroutine in step 5. **Deadlock.**
6. Req B: client.Do invokes client.do, a new request is written to the server however its innerHandler callback will never be called as client.processLoop is parked attempting to lock respHandler
7. Req B: client.do() times out after client.ResponseTimeout seconds, releasing the respHandler lock and returning ErrLostConn. This works around the deadlock.

Second race condition (much rarer) occurs in this scenario:
1. Req A: client.Do called, sends request
2. Req A: Server sends dtJobCreated, client.processLoop calls client.handleInner which gets the `"c"` callback, invokes it via `h(resp)`, goroutine execution suspends before it removes it
3. Req A: client.Do call completes. All locks are relinquished
4. Req B: client.Do called, assigns a new innerHandler callback `"c"` which overrides Req A `"c"` callback (as it has not yet been removed in step 2)
5. Req A: Step 2 execution resumes, deleting the Req B `"c"` callback assuming it was Req A's.
6. Req B: Server sends dtJobCreated, `h, ok := client.innerHandler.get(key); ok` evaluates to false as the B's callback was wrongly deleted in step 5
7. Req B: client.do() times out after client.ResponseTimeout seconds returning ErrLostConn. This works around the race condition.