### PR TITLE
add support for own ids (coalescing)

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrWorkWarning   = errors.New("Work warning")
 	ErrInvalidData   = errors.New("Invalid data")
+	ErrInvalidId     = errors.New("Invalid ID")
 	ErrWorkFail      = errors.New("Work fail")
 	ErrWorkException = errors.New("Work exeption")
 	ErrDataType      = errors.New("Invalid data type")


### PR DESCRIPTION
This is the use case:
When job queue contains million of messages sent to the same worker(Job name), I want that messages containing the SAME data to be processed only once. 
So it should depend on the client to assign the same ID on the messages that contains the same data.

On Gearman, the pair of JobName - JobID is unique. 


http://gearman.org/protocol/

The unique ID can be used by the server to reduce queue length. If a
    job with the same Unique ID has already been submitted, the server
    may attach this request to the already existing job. This includes
    jobs already in progress, in which case non-background jobs will be
    sent the same result as background jobs. This is known commonly as
    "coalescing".

